### PR TITLE
feat(net): Peer Backchannel [RFC]

### DIFF
--- a/crates/net/src/driver.rs
+++ b/crates/net/src/driver.rs
@@ -6,8 +6,10 @@ use crate::{
 };
 use alloy::primitives::Address;
 use eyre::Result;
+use tracing::error;
 use std::sync::mpsc::Receiver;
 use tokio::{select, sync::watch};
+use crate::types::peer::Peer;
 
 /// NetworkDriver
 ///
@@ -44,14 +46,21 @@ impl NetworkDriver {
 
     /// Starts the Discv5 peer discovery & libp2p services
     /// and continually listens for new peers and messages to handle
-    pub fn start(mut self) -> Result<()> {
+    pub fn start(mut self) -> Result<Receiver<Peer>> {
         let mut peer_recv = self.discovery.start()?;
+        let (backchannel_peer_send, backchannel_peer_recv) = std::sync::mpsc::channel::<Peer>();
         self.gossip.listen()?;
         tokio::spawn(async move {
             loop {
                 select! {
                     peer = peer_recv.recv() => {
-                        self.gossip.dial_opt(peer).await;
+                        self.gossip.dial_opt(peer.clone()).await;
+                        let Some(peer) = peer else {
+                            break;
+                        };
+                        if let Err(e) = backchannel_peer_send.send(peer.clone()) {
+                            error!("Failed to send peer to backchannel: {:?}", e);
+                        }
                     },
                     event = self.gossip.select_next_some() => {
                         self.gossip.handle_event(event);
@@ -60,6 +69,6 @@ impl NetworkDriver {
             }
         });
 
-        Ok(())
+        Ok(backchannel_peer_recv)
     }
 }

--- a/crates/net/src/driver.rs
+++ b/crates/net/src/driver.rs
@@ -1,15 +1,16 @@
 //! Driver for network services.
 
 use crate::{
-    builder::NetworkDriverBuilder, discovery::driver::DiscoveryDriver,
-    gossip::driver::GossipDriver, types::envelope::ExecutionPayloadEnvelope,
+    builder::NetworkDriverBuilder,
+    discovery::driver::DiscoveryDriver,
+    gossip::driver::GossipDriver,
+    types::{envelope::ExecutionPayloadEnvelope, peer::Peer},
 };
 use alloy::primitives::Address;
 use eyre::Result;
-use tracing::error;
 use std::sync::mpsc::Receiver;
 use tokio::{select, sync::watch};
-use crate::types::peer::Peer;
+use tracing::error;
 
 /// NetworkDriver
 ///

--- a/crates/net/src/types/peer.rs
+++ b/crates/net/src/types/peer.rs
@@ -6,7 +6,7 @@ use libp2p::{multiaddr::Protocol, Multiaddr};
 use std::net::{IpAddr, SocketAddr};
 
 /// A wrapper around a peer's [SocketAddr].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Peer {
     /// The peer's [SocketAddr].
     pub socket: SocketAddr,


### PR DESCRIPTION
### Description

Not particularly keen with this. It effectively allows the consumer of the `NetworkDriver` to have a handle into peers dialed for discovery. This is done this way since the driver is [_consumed_](https://github.com/paradigmxyz/op-rs/blob/main/crates/net/src/driver.rs#L47) when starting the network service. Ultimately, this leads me to believe the `net` crate needs better trait abstractions.