### PR TITLE
feat(rollup): Engine RPC API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lcov.info
 
 # Rust bug report
 rustc-ice-*
+
+# Used for testing
+jwt.hex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
@@ -4007,10 +4008,10 @@ dependencies = [
  "kona-primitives",
  "lru",
  "miniz_oxide",
- "op-alloy-consensus",
- "op-alloy-genesis",
- "op-alloy-protocol",
- "op-alloy-rpc-types-engine",
+ "op-alloy-consensus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-protocol 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "serde",
  "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
@@ -4029,9 +4030,9 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "c-kzg",
- "op-alloy-consensus",
- "op-alloy-genesis",
- "op-alloy-protocol",
+ "op-alloy-consensus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-protocol 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "revm",
  "serde",
  "sha2 0.10.8",
@@ -4050,7 +4051,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "kona-derive",
  "kona-primitives",
- "op-alloy-protocol",
+ "op-alloy-protocol 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.12.3",
  "reth",
  "tracing",
@@ -5195,10 +5196,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-consensus"
+version = "0.2.12"
+source = "git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72#f6d9d723fff605c8b87a95548d4eb56338dc2c1e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "op-alloy-genesis"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1b8a9b70da0e027242ec1762f0f3a386278b6291d00d12ff5a64929dc19f68"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_repr",
+]
+
+[[package]]
+name = "op-alloy-genesis"
+version = "0.2.12"
+source = "git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72#f6d9d723fff605c8b87a95548d4eb56338dc2c1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5220,9 +5249,39 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "hashbrown 0.14.5",
- "op-alloy-consensus",
- "op-alloy-genesis",
+ "op-alloy-consensus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
+]
+
+[[package]]
+name = "op-alloy-protocol"
+version = "0.2.12"
+source = "git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72#f6d9d723fff605c8b87a95548d4eb56338dc2c1e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "hashbrown 0.14.5",
+ "op-alloy-consensus 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
+ "op-alloy-genesis 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
+ "serde",
+]
+
+[[package]]
+name = "op-alloy-provider"
+version = "0.2.12"
+source = "git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72#f6d9d723fff605c8b87a95548d4eb56338dc2c1e"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "op-alloy-rpc-types-engine 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
 ]
 
 [[package]]
@@ -5238,7 +5297,7 @@ dependencies = [
  "alloy-serde",
  "cfg-if",
  "hashbrown 0.14.5",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
 ]
@@ -5254,9 +5313,25 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-serde",
  "derive_more",
- "op-alloy-consensus",
- "op-alloy-genesis",
- "op-alloy-protocol",
+ "op-alloy-consensus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-protocol 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.2.12"
+source = "git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72#f6d9d723fff605c8b87a95548d4eb56338dc2c1e"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
+ "op-alloy-genesis 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
+ "op-alloy-protocol 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
  "serde",
 ]
 
@@ -8072,7 +8147,7 @@ dependencies = [
  "alloy-serde",
  "jsonrpsee-types",
  "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -8586,9 +8661,10 @@ dependencies = [
  "kona-derive",
  "kona-providers",
  "metrics-exporter-prometheus",
- "op-alloy-genesis",
- "op-alloy-protocol",
- "op-alloy-rpc-types-engine",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-protocol 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-provider",
+ "op-alloy-rpc-types-engine 0.2.12 (git+https://github.com/alloy-rs/op-alloy?rev=f6d9d72)",
  "reqwest",
  "reth",
  "reth-execution-types",
@@ -8596,7 +8672,9 @@ dependencies = [
  "reth-node-api",
  "serde_json",
  "superchain",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -8999,8 +9077,8 @@ dependencies = [
  "alloy-rlp",
  "eyre",
  "kona-derive",
- "op-alloy-genesis",
- "op-alloy-protocol",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-protocol 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "op-alloy-rpc-types",
  "rand",
  "tracing",
@@ -9432,7 +9510,7 @@ dependencies = [
  "alloy-primitives",
  "hashbrown 0.14.5",
  "lazy_static",
- "op-alloy-genesis",
+ "op-alloy-genesis 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ alloy = { version = "0.3.6", features = [
     "consensus",
     "rpc-types",
     "rpc-types-engine",
+    "json-rpc",
     "network",
     "ssz"
 ] }
@@ -60,8 +61,10 @@ alloy-primitives = { version = "0.8", features = ["serde"] }
 alloy-rlp = "0.3"
 op-alloy-protocol = { version = "0.2.12", default-features = false }
 op-alloy-rpc-types = { version = "0.2.12", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.2.12", default-features = false }
 op-alloy-genesis = { version = "0.2.12", default-features = false }
+# TODO: Use a new version once it's released
+op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "f6d9d72", default-features = false }
+op-alloy-provider = { git = "https://github.com/alloy-rs/op-alloy", rev = "f6d9d72", default-features = false }
 
 # Tokio
 tokio = { version = "1.21", default-features = false }
@@ -110,6 +113,7 @@ hashbrown = "0.14.5"
 parking_lot = "0.12.3"
 unsigned-varint = "0.8.0"
 rand = { version = "0.8.3", features = ["small_rng"], default-features = false }
+thiserror = "1.0.63"
 url = "2.5.2"
 
 [workspace.metadata.docs.rs]

--- a/bin/op-rs/src/main.rs
+++ b/bin/op-rs/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
 
             let cfg = hera_args.get_l2_config()?;
             let node = EthereumNode::default();
-            let hera = move |ctx| async { Ok(Driver::exex(ctx, hera_args, cfg).start()) };
+            let hera = move |ctx| async { Ok(Driver::exex(ctx, hera_args, cfg).await.start()) };
             let handle = builder.node(node).install_exex(HERA_EXEX_ID, hera).launch().await?;
             handle.wait_for_node_exit().await
         } else {

--- a/crates/net/src/discovery/driver.rs
+++ b/crates/net/src/discovery/driver.rs
@@ -1,7 +1,7 @@
 //! Discovery Module.
 
 use eyre::Result;
-use std::time::Duration;
+use std::{fmt::Debug, time::Duration};
 use tokio::{
     sync::mpsc::{channel, Receiver},
     time::sleep,
@@ -24,6 +24,12 @@ pub struct DiscoveryDriver {
     pub disc: Discv5,
     /// The chain ID of the network.
     pub chain_id: u64,
+}
+
+impl Debug for DiscoveryDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscoveryDriver").field("chain_id", &self.chain_id).finish()
+    }
 }
 
 impl DiscoveryDriver {

--- a/crates/net/src/driver.rs
+++ b/crates/net/src/driver.rs
@@ -15,6 +15,7 @@ use tokio::{select, sync::watch};
 /// There are two core services that are run by the driver:
 /// - Block gossip through Gossipsub.
 /// - Peer discovery with `discv5`.
+#[derive(Debug)]
 pub struct NetworkDriver {
     /// Channel to receive unsafe blocks.
     pub(crate) unsafe_block_recv: Option<Receiver<ExecutionPayloadEnvelope>>,

--- a/crates/net/src/gossip/driver.rs
+++ b/crates/net/src/gossip/driver.rs
@@ -1,5 +1,7 @@
 //! Consensus-layer gossipsub driver for Optimism.
 
+use std::fmt::Debug;
+
 use crate::gossip::{
     behaviour::Behaviour,
     event::Event,
@@ -18,6 +20,12 @@ pub struct GossipDriver {
     pub addr: Multiaddr,
     /// Block handler.
     pub handler: BlockHandler,
+}
+
+impl Debug for GossipDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GossipDriver").field("addr", &self.addr).finish()
+    }
 }
 
 impl GossipDriver {

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+# Workspace
 kona-providers.workspace = true
 
 # OP Stack Dependencies
@@ -17,6 +18,7 @@ kona-derive.workspace = true
 op-alloy-genesis.workspace = true
 op-alloy-protocol.workspace = true
 op-alloy-rpc-types-engine.workspace = true
+op-alloy-provider.workspace = true
 superchain = { workspace = true, default-features = false }
 
 # Reth Dependencies
@@ -28,6 +30,9 @@ reth-execution-types.workspace = true
 # Telemetry
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }   
 metrics-exporter-prometheus = { version = "0.15.3", features = ["http-listener"] }
+
+# Async
+tower = "0.4"
 
 # Misc 
 url.workspace = true
@@ -41,6 +46,7 @@ tokio.workspace = true
 futures.workspace = true
 alloy.workspace = true
 hashbrown.workspace = true
+thiserror.workspace = true
 
 [features]
 default = ["online"]

--- a/crates/rollup/src/driver/context/mod.rs
+++ b/crates/rollup/src/driver/context/mod.rs
@@ -79,8 +79,13 @@ impl Blocks {
         *self.0.last_key_value().expect("Blocks should have at least one block").0
     }
 
-    /// Returns the block at the fork point of the chain.
-    pub fn fork_block(&self) -> BlockNumber {
+    /// Returns a reference to the block at the tip of the chain.
+    pub fn tip_block(&self) -> &Block<TxEnvelope> {
+        self.0.get(&self.tip()).expect("Blocks should have at least one block")
+    }
+
+    /// Returns the block number at the fork point of the chain (the block before the first).
+    pub fn fork_block_number(&self) -> BlockNumber {
         let first = self.0.first_key_value().expect("Blocks should have at least one block").0;
         first.saturating_sub(1)
     }

--- a/crates/rollup/src/engine/mod.rs
+++ b/crates/rollup/src/engine/mod.rs
@@ -1,0 +1,148 @@
+use alloy::{
+    network::AnyNetwork,
+    primitives::B256,
+    providers::RootProvider,
+    rpc::client::ClientBuilder,
+    transports::{BoxTransport, TransportErrorKind, TransportResult},
+};
+use op_alloy_provider::ext::engine::OpEngineApi;
+use op_alloy_rpc_types_engine::{
+    OptimismExecutionPayloadEnvelopeV3, OptimismExecutionPayloadEnvelopeV4,
+    OptimismPayloadAttributes, ProtocolVersion, SuperchainSignal,
+};
+use reth::{
+    payload::PayloadId,
+    rpc::types::{
+        engine::{
+            ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2, ForkchoiceState,
+            ForkchoiceUpdated, JwtSecret, PayloadStatus,
+        },
+        ExecutionPayload,
+    },
+};
+use reth_node_api::EngineApiMessageVersion;
+use url::Url;
+
+mod transport;
+use transport::AuthenticatedTransportConnect;
+
+#[derive(Debug, Clone)]
+pub struct EngineApiClient {
+    auth_provider: RootProvider<BoxTransport, AnyNetwork>,
+}
+
+impl EngineApiClient {
+    /// Creates a new [`EngineApiClient`] instance.
+    pub async fn new(rpc_url: Url, jwt: JwtSecret) -> eyre::Result<Self> {
+        let auth_transport = AuthenticatedTransportConnect::new(rpc_url, jwt);
+        let client = ClientBuilder::default().connect_boxed(auth_transport).await?;
+        Ok(Self { auth_provider: RootProvider::<_, AnyNetwork>::new(client) })
+    }
+
+    /// Calls the `engine_newPayload` method on the engine API.
+    ///
+    /// - The version is determined by the execution payload version passed in.
+    /// - Returns the engine API message version and the payload status.
+    pub async fn new_payload(
+        &self,
+        payload: ExecutionPayload,
+        parent_beacon_block_root: Option<B256>,
+    ) -> TransportResult<(EngineApiMessageVersion, PayloadStatus)> {
+        match payload {
+            ExecutionPayload::V4(payload) => {
+                let parent_root = parent_beacon_block_root.ok_or_else(|| {
+                    TransportErrorKind::custom_str("parent beacon root must be provided")
+                })?;
+
+                Ok((
+                    EngineApiMessageVersion::V4,
+                    self.auth_provider.new_payload_v4(payload, parent_root).await?,
+                ))
+            }
+            ExecutionPayload::V3(payload) => {
+                let parent_root = parent_beacon_block_root.ok_or_else(|| {
+                    TransportErrorKind::custom_str("parent beacon root must be provided")
+                })?;
+
+                Ok((
+                    EngineApiMessageVersion::V3,
+                    self.auth_provider.new_payload_v3(payload, parent_root).await?,
+                ))
+            }
+            ExecutionPayload::V2(payload) => {
+                let input = ExecutionPayloadInputV2 {
+                    execution_payload: payload.payload_inner,
+                    withdrawals: Some(payload.withdrawals),
+                };
+
+                Ok((EngineApiMessageVersion::V2, self.auth_provider.new_payload_v2(input).await?))
+            }
+            ExecutionPayload::V1(_) => {
+                Err(TransportErrorKind::custom_str("V1 payloads are not supported"))
+            }
+        }
+    }
+
+    /// Calls the `engine_getPayload` method on the engine API.
+    ///
+    /// - The version is determined by the execution payload version passed in.
+    /// - Returns the execution payload envelope based on the version.
+    pub async fn get_payload(
+        &self,
+        message_version: EngineApiMessageVersion,
+        payload_id: PayloadId,
+    ) -> TransportResult<GetPayloadResponse> {
+        match message_version {
+            EngineApiMessageVersion::V1 | EngineApiMessageVersion::V2 => {
+                Ok(GetPayloadResponse::V2(self.auth_provider.get_payload_v2(payload_id).await?))
+            }
+            EngineApiMessageVersion::V3 => {
+                Ok(GetPayloadResponse::V3(self.auth_provider.get_payload_v3(payload_id).await?))
+            }
+            EngineApiMessageVersion::V4 => {
+                Ok(GetPayloadResponse::V4(self.auth_provider.get_payload_v4(payload_id).await?))
+            }
+        }
+    }
+
+    /// Calls the `fork_choice_updated` method on the engine API.
+    ///
+    /// - The version is determined by the execution payload version passed in.
+    /// - Returns the fork choice updated response.
+    pub async fn fork_choice_updated(
+        &self,
+        message_version: EngineApiMessageVersion,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OptimismPayloadAttributes>,
+    ) -> TransportResult<ForkchoiceUpdated> {
+        match message_version {
+            EngineApiMessageVersion::V4 | EngineApiMessageVersion::V3 => {
+                self.auth_provider
+                    .fork_choice_updated_v3(fork_choice_state, payload_attributes)
+                    .await
+            }
+            EngineApiMessageVersion::V1 | EngineApiMessageVersion::V2 => {
+                self.auth_provider
+                    .fork_choice_updated_v2(fork_choice_state, payload_attributes)
+                    .await
+            }
+        }
+    }
+
+    /// Calls the `signal_superchain` method on the engine API.
+    ///
+    /// - Returns the latest protocol version supported by the execution engine.
+    pub async fn signal_superchain(
+        &self,
+        signal: SuperchainSignal,
+    ) -> TransportResult<ProtocolVersion> {
+        self.auth_provider.signal_superchain_v1(signal).await
+    }
+}
+
+/// The response from the `engine_getPayload` versioned method.
+pub enum GetPayloadResponse {
+    V2(ExecutionPayloadEnvelopeV2),
+    V3(OptimismExecutionPayloadEnvelopeV3),
+    V4(OptimismExecutionPayloadEnvelopeV4),
+}

--- a/crates/rollup/src/engine/transport.rs
+++ b/crates/rollup/src/engine/transport.rs
@@ -1,0 +1,241 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use alloy::{
+    providers::{IpcConnect, WsConnect},
+    pubsub::{PubSubConnect, PubSubFrontend},
+    rpc::json_rpc::{RequestPacket, ResponsePacket},
+    transports::{
+        http::{Http, ReqwestTransport},
+        utils::guess_local_url,
+        Authorization, Pbf, TransportConnect, TransportError, TransportErrorKind, TransportFut,
+    },
+};
+use futures::FutureExt;
+use reqwest::{
+    header::{self, HeaderValue},
+    Client,
+};
+use reth::rpc::types::engine::{Claims, JwtSecret};
+use tokio::sync::RwLock;
+use tower::Service;
+use url::Url;
+
+/// An enum representing the different transports that can be used to connect to a runtime.
+/// Only meant to be used internally by [`AuthenticatedTransport`].
+#[derive(Clone, Debug)]
+pub enum InnerTransport {
+    /// HTTP transport
+    Http(ReqwestTransport),
+    /// `WebSocket` transport
+    Ws(PubSubFrontend),
+    /// IPC transport
+    Ipc(PubSubFrontend),
+}
+
+impl InnerTransport {
+    /// Connects to a transport based on the given URL and JWT.
+    /// Returns an [`InnerTransport`] and the [`Claims`] generated from the jwt.
+    async fn connect(url: Url, jwt: JwtSecret) -> Result<(Self, Claims), AuthTransportError> {
+        match url.scheme() {
+            "http" | "https" => Self::connect_http(url, jwt),
+            "ws" | "wss" => Self::connect_ws(url, jwt).await,
+            "file" => Ok((Self::connect_ipc(url).await?, Claims::default())),
+            _ => Err(AuthTransportError::BadScheme(url.scheme().to_string())),
+        }
+    }
+
+    /// Connects to an HTTP transport.
+    /// Returns an [`InnerTransport`] and the [Claims] generated from the jwt.
+    fn connect_http(url: Url, jwt: JwtSecret) -> Result<(Self, Claims), AuthTransportError> {
+        let mut client_builder = Client::builder().tls_built_in_root_certs(url.scheme() == "https");
+
+        // Add the JWT it to the headers if we can decode it.
+        let (auth, claims) = build_auth(jwt).map_err(AuthTransportError::InvalidJwt)?;
+
+        let mut auth_value = HeaderValue::from_str(&auth.to_string()).expect("invalid string");
+        auth_value.set_sensitive(true);
+
+        let mut headers = header::HeaderMap::new();
+        headers.insert(header::AUTHORIZATION, auth_value);
+        client_builder = client_builder.default_headers(headers);
+
+        let client = client_builder.build().map_err(AuthTransportError::HttpConstructionError)?;
+        let inner = Self::Http(Http::with_client(client, url));
+
+        Ok((inner, claims))
+    }
+
+    /// Connects to a `WebSocket` transport.
+    /// Returns an [`InnerTransport`] and the [`Claims`] generated from the jwt.
+    async fn connect_ws(url: Url, jwt: JwtSecret) -> Result<(Self, Claims), AuthTransportError> {
+        // Add the JWT to the headers if we can decode it.
+        let (auth, claims) = build_auth(jwt).map_err(AuthTransportError::InvalidJwt)?;
+
+        let ws = WsConnect { url: url.to_string(), auth: Some(auth) };
+
+        match ws.into_service().await {
+            Ok(ws) => Ok((Self::Ws(ws), claims)),
+            Err(e) => Err(AuthTransportError::TransportError(e, url.to_string())),
+        }
+    }
+
+    /// Connects to an IPC transport. Returns an [`InnerTransport`].
+    /// Does not return any [`Claims`] because IPC does not require them.
+    async fn connect_ipc(url: Url) -> Result<Self, AuthTransportError> {
+        // IPC, even for engine, typically does not require auth because it's local
+        let ipc = IpcConnect::new(url.to_string());
+
+        match ipc.into_service().await {
+            Ok(ipc) => Ok(Self::Ipc(ipc)),
+            Err(e) => Err(AuthTransportError::TransportError(e, url.to_string())),
+        }
+    }
+}
+
+/// An error that can occur when creating an authenticated transport.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthTransportError {
+    /// The JWT is invalid.
+    #[error("The JWT is invalid: {0}")]
+    InvalidJwt(eyre::Error),
+    /// The transport failed to connect.
+    #[error("The transport failed to connect to {1}, transport error: {0}")]
+    TransportError(TransportError, String),
+    /// The http client could not be built.
+    #[error("The http client could not be built")]
+    HttpConstructionError(reqwest::Error),
+    /// The scheme is invalid.
+    #[error("The URL scheme is invalid: {0}")]
+    BadScheme(String),
+}
+
+/// An authenticated transport that can be used to send requests that contain a jwt bearer token.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedTransport {
+    /// The inner actual transport used.
+    ///
+    /// Also contains the current claims being used. This is used to determine whether or not we
+    /// should create another client.
+    inner_and_claims: Arc<RwLock<(InnerTransport, Claims)>>,
+    /// The current jwt being used. This is so we can recreate claims.
+    jwt: JwtSecret,
+    /// The current URL being used. This is so we can recreate the client if needed.
+    url: Url,
+}
+
+impl AuthenticatedTransport {
+    /// Create a new builder with the given URL and JWT secret.
+    pub async fn connect(url: Url, jwt: JwtSecret) -> Result<Self, AuthTransportError> {
+        let (inner, claims) = InnerTransport::connect(url.clone(), jwt).await?;
+        Ok(Self { inner_and_claims: Arc::new(RwLock::new((inner, claims))), jwt, url })
+    }
+
+    /// Sends a request using the underlying transport.
+    ///
+    /// For sending the actual request, this action is delegated down to the underlying transport
+    /// through Tower's [`tower::Service::call`].
+    ///
+    /// See tower's [`tower::Service`] trait for more information.
+    fn request(&self, req: RequestPacket) -> TransportFut<'static> {
+        let this = self.clone();
+
+        Box::pin(async move {
+            let mut inner_and_claims = this.inner_and_claims.write().await;
+
+            // shift the iat forward by one second so there is some buffer time
+            let mut shifted_claims = inner_and_claims.1;
+            shifted_claims.iat -= 1;
+
+            // if the claims are out of date, reset the inner transport
+            if !shifted_claims.is_within_time_window() {
+                match InnerTransport::connect(this.url, this.jwt).await {
+                    Ok((new_inner, new_claims)) => *inner_and_claims = (new_inner, new_claims),
+                    Err(e) => return Err(TransportErrorKind::custom(Box::new(e))),
+                }
+            }
+
+            match inner_and_claims.0 {
+                InnerTransport::Http(ref mut http) => http.call(req),
+                InnerTransport::Ws(ref mut ws) => ws.call(req),
+                InnerTransport::Ipc(ref mut ipc) => ipc.call(req),
+            }
+            .await
+        })
+    }
+}
+
+/// Generate claims (iat with current timestamp).
+/// This happens by default using the Default trait for Claims.
+fn build_auth(secret: JwtSecret) -> eyre::Result<(Authorization, Claims)> {
+    let claims = Claims::default();
+    let token = secret.encode(&claims)?;
+    let auth = Authorization::Bearer(token);
+
+    Ok((auth, claims))
+}
+
+/// This specifies how to connect to an authenticated transport.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedTransportConnect {
+    /// The URL to connect to.
+    url: Url,
+    /// The JWT secret used to authenticate the transport.
+    jwt: JwtSecret,
+}
+
+impl AuthenticatedTransportConnect {
+    /// Create a new builder with the given URL.
+    pub const fn new(url: Url, jwt: JwtSecret) -> Self {
+        Self { url, jwt }
+    }
+}
+
+impl TransportConnect for AuthenticatedTransportConnect {
+    type Transport = AuthenticatedTransport;
+
+    fn is_local(&self) -> bool {
+        guess_local_url(&self.url)
+    }
+
+    fn get_transport<'a: 'b, 'b>(&'a self) -> Pbf<'b, Self::Transport, TransportError> {
+        AuthenticatedTransport::connect(self.url.clone(), self.jwt)
+            .map(|res| match res {
+                Ok(transport) => Ok(transport),
+                Err(err) => {
+                    Err(TransportError::Transport(TransportErrorKind::Custom(Box::new(err))))
+                }
+            })
+            .boxed()
+    }
+}
+
+impl tower::Service<RequestPacket> for AuthenticatedTransport {
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        self.request(req)
+    }
+}
+
+impl tower::Service<RequestPacket> for &AuthenticatedTransport {
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        self.request(req)
+    }
+}

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -10,6 +10,9 @@ pub use driver::Driver;
 mod cli;
 pub use cli::HeraArgsExt;
 
+mod engine;
+pub use engine::EngineApiClient;
+
 mod validator;
 pub use validator::AttributesValidator;
 


### PR DESCRIPTION
### Overview

This PR adds an Engine RPC API client using the new [`op_alloy_provider::ext::engine::OpEngineApi`](https://github.com/alloy-rs/op-alloy/pull/117).
It also adds an authenticated transport borrowed from Reth's.

> [!NOTE]
> This is not compiling right now, because of inconsistencies between the op_alloy version used by Kona and Op-rs.
> We can move forward by patching Kona if needed for testing.

### Meta

- closes #11